### PR TITLE
updates google-cloud-pubsub from 1.114.0 to 1.115.5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val log4cats       = "2.1.1"
     val jwt            = "3.18.2"
     val jsoniter       = "2.10.2"
-    val gcp            = "1.114.0"
+    val gcp            = "1.115.5"
     val scalatest      = "3.2.9"
     val scalatestPlus  = "3.2.2.0"
     val testContainers = "0.39.7"


### PR DESCRIPTION
As per the title. It would be great if we could get this in @CremboC and team, as it causes common dependency clash issues with (some) (newer) versions of other google cloud libraries.