### PR TITLE
Dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8, 2.12.15, 3.1.3]
+        scala: [2.13.10, 2.12.17, 3.2.0]
         java: [temurin@11]
         project: [rootJVM]
     runs-on: ${{ matrix.os }}
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8]
+        scala: [2.13.10]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -143,32 +143,32 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (2.13.8, rootJVM)
+      - name: Download target directories (2.13.10, rootJVM)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.10-rootJVM
 
-      - name: Inflate target directories (2.13.8, rootJVM)
+      - name: Inflate target directories (2.13.10, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.12.15, rootJVM)
+      - name: Download target directories (2.12.17, rootJVM)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.17-rootJVM
 
-      - name: Inflate target directories (2.12.15, rootJVM)
+      - name: Inflate target directories (2.12.17, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.1.3, rootJVM)
+      - name: Download target directories (3.2.0, rootJVM)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.3-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.0-rootJVM
 
-      - name: Inflate target directories (3.1.3, rootJVM)
+      - name: Inflate target directories (3.2.0, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Check that workflows are up to date
-        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' 'project /' githubWorkflowCheck
+        run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
         if: matrix.java == 'temurin@11'

--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,8 @@ ThisBuild / startYear := Some(2018)
 
 ThisBuild / tlSonatypeUseLegacyHost := true
 
-val Scala213 = "2.13.8"
-ThisBuild / crossScalaVersions := Seq(Scala213, "2.12.15", "3.1.3")
+val Scala213 = "2.13.10"
+ThisBuild / crossScalaVersions := Seq(Scala213, "2.12.17", "3.2.0")
 ThisBuild / scalaVersion := Scala213 // the default Scala
 ThisBuild / tlJdkRelease := Some(11)
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -31,8 +31,9 @@ import fs2.{Chunk, Stream}
 import org.threeten.bp.Duration
 
 import java.util
-import scala.jdk.CollectionConverters._
 import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
+import scala.jdk.CollectionConverters._
+import scala.collection.mutable.Builder
 
 private[consumer] object PubsubSubscriber {
 
@@ -95,11 +96,11 @@ private[consumer] object PubsubSubscriber {
         if (nextOpt == null) Sync[F].interruptibleMany(messages.take())
         else Applicative[F].pure(nextOpt)
       chunk <- Sync[F].delay {
-        val elements = new util.ArrayList[A]
-        elements.add(next)
-        messages.drainTo(elements)
+        val c = Wrapper.empty[A]
+        c.add(next)
+        messages.drainTo(c)
 
-        Chunk.indexedSeq(elements.asScala.toIndexedSeq)
+        c.toChunk
       }
     } yield chunk
 
@@ -117,4 +118,50 @@ private[consumer] object PubsubSubscriber {
       // Only retains the first error (if there are multiple), but that is OK, the stream is failing anyway...
       msg <- Stream.fromEither[F](taken.sequence).unchunks
     } yield msg
+}
+
+/** A wrapper that implements `java.util.Collection[A]` for `Builder[A, Vector[A]]`
+  * so that we can pass the builder directly to the underlying library and
+  * avoid copying
+  */
+private[consumer] class Wrapper[A](val underlying: Builder[A, Vector[A]]) extends util.Collection[A] {
+
+  override def size(): Int = ???
+
+  override def isEmpty(): Boolean = ???
+
+  override def contains(x$1: Object): Boolean = ???
+
+  override def iterator(): util.Iterator[A] = ???
+
+  override def toArray(): Array[Object] = ???
+
+  override def toArray[T <: Object](x$1: Array[T with Object]): Array[T with Object] = ???
+
+  override def add(a: A): Boolean = {
+    underlying += a
+    true
+  }
+
+  override def remove(x$1: Object): Boolean = ???
+
+  override def containsAll(x$1: util.Collection[_ <: Object]): Boolean = ???
+
+  override def addAll(as: util.Collection[_ <: A]): Boolean = {
+    underlying.addAll(as.asScala)
+    true
+  }
+
+  override def removeAll(x$1: util.Collection[_ <: Object]): Boolean = ???
+
+  override def retainAll(x$1: util.Collection[_ <: Object]): Boolean = ???
+
+  override def clear(): Unit = ???
+
+  def toChunk: Chunk[A] = Chunk.vector(underlying.result())
+
+}
+
+object Wrapper {
+  def empty[A]: Wrapper[A] = new Wrapper(Vector.newBuilder[A])
 }

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -138,25 +138,25 @@ private[consumer] class Wrapper[A](val underlying: Builder[A, Vector[A]]) extend
 
   override def toArray(): Array[Object] = ???
 
-  override def toArray[T <: Object](x$1: Array[T with Object]): Array[T with Object] = ???
+  override def toArray[T](x$1: Array[T with Object]): Array[T with Object] = ???
 
-  override def add(a: A): Boolean = {
-    underlying += a
+  override def add(x: A): Boolean = {
+    underlying += x
     true
   }
 
   override def remove(x$1: Object): Boolean = ???
 
-  override def containsAll(x$1: util.Collection[_ <: Object]): Boolean = ???
+  override def containsAll(x$1: util.Collection[_]): Boolean = ???
 
-  override def addAll(as: util.Collection[_ <: A]): Boolean = {
-    underlying.addAll(as.asScala)
+  override def addAll(xs: util.Collection[_ <: A]): Boolean = {
+    underlying ++= xs.asScala
     true
   }
 
-  override def removeAll(x$1: util.Collection[_ <: Object]): Boolean = ???
+  override def removeAll(x$1: util.Collection[_]): Boolean = ???
 
-  override def retainAll(x$1: util.Collection[_ <: Object]): Boolean = ???
+  override def retainAll(x$1: util.Collection[_]): Boolean = ???
 
   override def clear(): Unit = ???
 

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -122,8 +122,10 @@ private[consumer] object PubsubSubscriber {
 
 /** A wrapper that implements `java.util.Collection[A]` for `Builder[A, Vector[A]]`
   * so that we can pass the builder directly to the underlying library and
-  * avoid copying
-  */
+ * avoid copying.
+ *
+ * Only the minimal set of methods required are actually implemented.
+ */
 private[consumer] class Wrapper[A](val underlying: Builder[A, Vector[A]]) extends util.Collection[A] {
 
   override def size(): Int = ???

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -122,10 +122,10 @@ private[consumer] object PubsubSubscriber {
 
 /** A wrapper that implements `java.util.Collection[A]` for `Builder[A, Vector[A]]`
   * so that we can pass the builder directly to the underlying library and
- * avoid copying.
- *
- * Only the minimal set of methods required are actually implemented.
- */
+  * avoid copying.
+  *
+  * Only the minimal set of methods required are actually implemented.
+  */
 private[consumer] class Wrapper[A](val underlying: Builder[A, Vector[A]]) extends util.Collection[A] {
 
   override def size(): Int = ???

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -32,7 +32,6 @@ import org.threeten.bp.Duration
 
 import java.util
 import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, TimeUnit}
-import scala.jdk.CollectionConverters._
 import scala.collection.mutable.Builder
 
 private[consumer] object PubsubSubscriber {
@@ -150,7 +149,7 @@ private[consumer] class Wrapper[A](val underlying: Builder[A, Vector[A]]) extend
   override def containsAll(x$1: util.Collection[_]): Boolean = ???
 
   override def addAll(xs: util.Collection[_ <: A]): Boolean = {
-    underlying ++= xs.asScala
+    xs.forEach(x => underlying += x)
     true
   }
 

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -99,7 +99,7 @@ private[consumer] object PubsubSubscriber {
         elements.add(next)
         messages.drainTo(elements)
 
-        Chunk.buffer(elements.asScala)
+        Chunk.indexedSeq(elements.asScala.toIndexedSeq)
       }
     } yield chunk
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,17 +4,17 @@ object Dependencies {
   object Versions {
     val catsCore         = "2.8.0"
     val effect           = "3.3.14"
-    val fs2              = "3.1.2"
+    val fs2              = "3.3.0"
     val http4s           = "0.23.16"
-    val http4sOkHttp     = "0.23.10"
-    val log4cats         = "2.4.0"
+    val http4sOkHttp     = "0.23.11"
+    val log4cats         = "2.5.0"
     val jwt              = "3.18.2"
-    val jsoniter         = "2.13.36"
+    val jsoniter         = "2.17.9"
     val gcp              = "1.114.0"
     val scalatest        = "3.2.14"
-    val scalatestPlus    = "3.2.12.0"
+    val scalatestPlus    = "3.2.14.0"
     val testContainers   = "0.39.7"
-    val collectionCompat = "2.8.0"
+    val collectionCompat = "2.8.1"
   }
 
   object Libraries {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,12 +5,13 @@ object Dependencies {
     val catsCore         = "2.8.0"
     val effect           = "3.3.14"
     val fs2              = "3.1.2"
-    val http4s           = "0.23.10"
+    val http4s           = "0.23.16"
+    val http4sOkHttp     = "0.23.10"
     val log4cats         = "2.4.0"
     val jwt              = "3.18.2"
     val jsoniter         = "2.13.36"
     val gcp              = "1.114.0"
-    val scalatest        = "3.2.12"
+    val scalatest        = "3.2.14"
     val scalatestPlus    = "3.2.12.0"
     val testContainers   = "0.39.7"
     val collectionCompat = "2.8.0"
@@ -24,7 +25,7 @@ object Dependencies {
 
     val http4sDsl    = "org.http4s" %% "http4s-dsl"           % Versions.http4s
     val http4sClient = "org.http4s" %% "http4s-client"        % Versions.http4s
-    val http4sHttp   = "org.http4s" %% "http4s-okhttp-client" % Versions.http4s % Test
+    val http4sHttp   = "org.http4s" %% "http4s-okhttp-client" % Versions.http4sOkHttp % Test
 
     val log4cats      = "org.typelevel" %% "log4cats-core"  % Versions.log4cats
     val log4catsSlf4j = "org.typelevel" %% "log4cats-slf4j" % Versions.log4cats % Test

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.12")
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.16")


### PR DESCRIPTION
Update all the things.

fs2 deprecated directly wrapping a `scala.collection.mutable.Buffer` into a `Chunk` so we introduced a wrapper class that implements `java.util.Collection[A]` and delegates to a `Builder[A, Vector[A]]` to avoid copying.