### PR TITLE
expose minDurationPerAckExtension and exactlyOnceDeliveryEnabled

### DIFF
--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
@@ -34,8 +34,8 @@ import scala.concurrent.duration._
 case class PubsubGoogleConsumerConfig[F[_]](
   maxQueueSize: Int = 1000,
   parallelPullCount: Int = 3,
-  maxAckExtensionPeriod: FiniteDuration = 0.seconds,
-  minDurationPerAckExtension: FiniteDuration = 60.seconds,
+  maxAckExtensionPeriod: FiniteDuration = 10.seconds,
+  minDurationPerAckExtension: FiniteDuration = 0.seconds,
   awaitTerminatePeriod: FiniteDuration = 30.seconds,
   onFailedTerminate: Throwable => F[Unit],
   customizeSubscriber: Option[Subscriber.Builder => Subscriber.Builder] = None

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
@@ -26,6 +26,7 @@ import scala.concurrent.duration._
   * @param maxQueueSize configures two options: the max size of the backing queue, and, the "max outstanding element count" option of Pubsub
   * @param parallelPullCount number of parallel pullers, see [[https://javadoc.io/static/com.google.cloud/google-cloud-pubsub/1.100.0/com/google/cloud/pubsub/v1/Subscriber.Builder.html#setParallelPullCount-int-]]
   * @param maxAckExtensionPeriod see [[https://javadoc.io/static/com.google.cloud/google-cloud-pubsub/1.100.0/com/google/cloud/pubsub/v1/Subscriber.Builder.html#setMaxAckExtensionPeriod-org.threeten.bp.Duration-]]
+  * @param minDurationPerAckExtension see [[https://javadoc.io/static/com.google.cloud/google-cloud-pubsub/1.120.8/com/google/cloud/pubsub/v1/Subscriber.Builder.html]]
   * @param awaitTerminatePeriod if the underlying PubSub subcriber fails to terminate cleanly, how long do we wait until it's forcibly timed out.
   * @param onFailedTerminate upon failure to terminate, call this function
   * @param customizeSubscriber optionally, provide a function that allows full customisation of the underlying Java Subscriber object.
@@ -34,6 +35,7 @@ case class PubsubGoogleConsumerConfig[F[_]](
   maxQueueSize: Int = 1000,
   parallelPullCount: Int = 3,
   maxAckExtensionPeriod: FiniteDuration = 10.seconds,
+  minDurationPerAckExtension: FiniteDuration = 60.seconds,
   awaitTerminatePeriod: FiniteDuration = 30.seconds,
   onFailedTerminate: Throwable => F[Unit],
   customizeSubscriber: Option[Subscriber.Builder => Subscriber.Builder] = None

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
@@ -30,6 +30,7 @@ import scala.concurrent.duration._
   * @param awaitTerminatePeriod if the underlying PubSub subcriber fails to terminate cleanly, how long do we wait until it's forcibly timed out.
   * @param onFailedTerminate upon failure to terminate, call this function
   * @param customizeSubscriber optionally, provide a function that allows full customisation of the underlying Java Subscriber object.
+  * @param exactlyOnceDeliveryEnabled, whether exactly-once-delivery is enabled on the subscription. Will update the minDurationPerAckExtension if a user-provided value is not set.
   */
 case class PubsubGoogleConsumerConfig[F[_]](
   maxQueueSize: Int = 1000,
@@ -38,5 +39,6 @@ case class PubsubGoogleConsumerConfig[F[_]](
   minDurationPerAckExtension: FiniteDuration = 0.seconds,
   awaitTerminatePeriod: FiniteDuration = 30.seconds,
   onFailedTerminate: Throwable => F[Unit],
-  customizeSubscriber: Option[Subscriber.Builder => Subscriber.Builder] = None
+  customizeSubscriber: Option[Subscriber.Builder => Subscriber.Builder] = None,
+  exactlyOnceDeliveryEnabled: Boolean = false
 )

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
@@ -34,7 +34,7 @@ import scala.concurrent.duration._
 case class PubsubGoogleConsumerConfig[F[_]](
   maxQueueSize: Int = 1000,
   parallelPullCount: Int = 3,
-  maxAckExtensionPeriod: FiniteDuration = 10.seconds,
+  maxAckExtensionPeriod: FiniteDuration = 0.seconds,
   minDurationPerAckExtension: FiniteDuration = 60.seconds,
   awaitTerminatePeriod: FiniteDuration = 30.seconds,
   onFailedTerminate: Throwable => F[Unit],

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -59,6 +59,7 @@ private[consumer] object PubsubSubscriber {
             )
             .setParallelPullCount(config.parallelPullCount)
             .setMaxAckExtensionPeriod(Duration.ofMillis(config.maxAckExtensionPeriod.toMillis))
+            .setMaxAckExtensionPeriod(Duration.ofMillis(config.minDurationPerAckExtension.toMillis))
 
         // if provided, use subscriber transformer to modify subscriber
         val sub =

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -60,6 +60,7 @@ private[consumer] object PubsubSubscriber {
             .setParallelPullCount(config.parallelPullCount)
             .setMaxAckExtensionPeriod(Duration.ofMillis(config.maxAckExtensionPeriod.toMillis))
             .setMaxAckExtensionPeriod(Duration.ofMillis(config.minDurationPerAckExtension.toMillis))
+            .setExactlyOnceDeliveryEnabled(config.exactlyOnceDeliveryEnabled)
 
         // if provided, use subscriber transformer to modify subscriber
         val sub =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val log4cats         = "2.5.0"
     val jwt              = "3.18.2"
     val jsoniter         = "2.17.9"
-    val gcp              = "1.114.0"
+    val gcp              = "1.116.0"
     val scalatest        = "3.2.14"
     val scalatestPlus    = "3.2.14.0"
     val testContainers   = "0.39.7"


### PR DESCRIPTION
Please see this issue: https://github.com/permutive-engineering/fs2-google-pubsub/issues/466

This PR exposes the field `minDurationPerAckExtension` and also the field `exactlyOnceDeliveryEnabled` which will automatically adjust `minDurationPerAckExtension` if it is not set.

Note that this is just for the `grpc` client. The `http` client will still have the same error detailed in the issue linked and will require a different solution.
