### PR TITLE
Deprecate everything inside the current library in favor of new `fs2-pubsub`

### DIFF
--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumer.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumer.scala
@@ -46,6 +46,10 @@ object PubsubGoogleConsumer {
     * @param subscription name of the subscription
     * @param errorHandler upon failure to decode, an exception is thrown. Allows acknowledging the message.
     */
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   final def subscribe[F[_]: Sync, A: MessageDecoder](
     projectId: Model.ProjectId,
     subscription: Model.Subscription,
@@ -77,6 +81,10 @@ object PubsubGoogleConsumer {
     * @param subscription name of the subscription
     * @param errorHandler upon failure to decode, an exception is thrown. Allows acknowledging the message.
     */
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   final def subscribeAndAck[F[_]: Sync, A: MessageDecoder](
     projectId: Model.ProjectId,
     subscription: Model.Subscription,
@@ -95,6 +103,10 @@ object PubsubGoogleConsumer {
     *
     * The stream fails with an [[InternalPubSubError]] if the underlying Java consumer fails.
     */
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   final def subscribeRaw[F[_]: Sync](
     projectId: Model.ProjectId,
     subscription: Model.Subscription,
@@ -106,6 +118,10 @@ object PubsubGoogleConsumer {
         ConsumerRecord(msg.value, msg.value.getAttributesMap.asScala.toMap, msg.ack, msg.nack, _ => Applicative[F].unit)
       )
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   private def subscribeDecode[F[_]: Sync, A: MessageDecoder, B](
     projectId: Model.ProjectId,
     subscription: Model.Subscription,

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/PubsubGoogleConsumerConfig.scala
@@ -29,6 +29,10 @@ import scala.concurrent.duration._
   * @param onFailedTerminate upon failure to terminate, call this function
   * @param customizeSubscriber optionally, provide a function that allows full customisation of the underlying Java Subscriber object.
   */
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 case class PubsubGoogleConsumerConfig[F[_]](
   maxQueueSize: Int = 1000,
   parallelPullCount: Int = 3,

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/consumer/grpc/internal/PubsubSubscriber.scala
@@ -36,6 +36,10 @@ import scala.collection.mutable.Builder
 
 private[consumer] object PubsubSubscriber {
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def createSubscriber[F[_]: Sync](
     projectId: PublicModel.ProjectId,
     subscription: PublicModel.Subscription,
@@ -103,6 +107,10 @@ private[consumer] object PubsubSubscriber {
       }
     } yield chunk
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def subscribe[F[_]: Sync](
     projectId: PublicModel.ProjectId,
     subscription: PublicModel.Subscription,

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/GooglePubsubProducer.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/GooglePubsubProducer.scala
@@ -23,6 +23,10 @@ import com.permutive.pubsub.producer.encoder.MessageEncoder
 import com.permutive.pubsub.producer.grpc.internal.{DefaultPublisher, PubsubPublisher}
 
 object GooglePubsubProducer {
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def of[F[_]: Async, A: MessageEncoder](
     projectId: ProjectId,
     topic: Topic,

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/PubsubProducerConfig.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/PubsubProducerConfig.scala
@@ -20,6 +20,10 @@ import com.google.cloud.pubsub.v1.Publisher
 
 import scala.concurrent.duration._
 
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 case class PubsubProducerConfig[F[_]](
   batchSize: Long,
   delayThreshold: FiniteDuration,

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/internal/DefaultPublisher.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/internal/DefaultPublisher.scala
@@ -29,6 +29,10 @@ import com.permutive.pubsub.producer.{Model, PubsubProducer}
 import java.util.UUID
 import scala.jdk.CollectionConverters._
 
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 private[pubsub] class DefaultPublisher[F[_]: Async, A: MessageEncoder](
   publisher: Publisher,
 ) extends PubsubProducer[F, A] {

--- a/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/internal/PubsubPublisher.scala
+++ b/fs2-google-pubsub-grpc/src/main/scala/com/permutive/pubsub/producer/grpc/internal/PubsubPublisher.scala
@@ -27,6 +27,10 @@ import org.threeten.bp.Duration
 
 import java.util.concurrent.TimeUnit
 
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 private[producer] object PubsubPublisher {
   def createJavaPublisher[F[_]: Sync](
     projectId: ProjectId,

--- a/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/GrpcPingPongSpec.scala
+++ b/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/GrpcPingPongSpec.scala
@@ -28,7 +28,9 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.concurrent.duration._
+import scala.annotation.nowarn
 
+@nowarn("cat=deprecation")
 class GrpcPingPongSpec extends PubSubSpec with BeforeAndAfterEach {
 
   implicit val logger: Logger[IO] = Slf4jLogger.getLogger

--- a/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/PubSubSpec.scala
+++ b/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/PubSubSpec.scala
@@ -44,7 +44,9 @@ import org.testcontainers.containers.wait.strategy.Wait
 import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration._
+import scala.annotation.nowarn
 
+@nowarn("cat=deprecation")
 trait PubSubSpec extends AnyFlatSpec with ForAllTestContainer with Matchers with TripleEquals {
 
   implicit val logger: Logger[IO]

--- a/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/ValueHolder.scala
+++ b/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/ValueHolder.scala
@@ -19,9 +19,11 @@ package com.permutive.pubsub
 import com.permutive.pubsub.consumer.decoder.MessageDecoder
 import com.permutive.pubsub.producer.encoder.MessageEncoder
 import scala.util.Try
+import scala.annotation.nowarn
 
 case class ValueHolder(value: String) extends AnyVal
 
+@nowarn("cat=deprecation")
 object ValueHolder {
   implicit val decoder: MessageDecoder[ValueHolder] = (bytes: Array[Byte]) => {
     Try(ValueHolder(new String(bytes))).toEither

--- a/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/consumer/grpc/SimpleDriver.scala
+++ b/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/consumer/grpc/SimpleDriver.scala
@@ -19,7 +19,9 @@ package com.permutive.pubsub.consumer.grpc
 import cats.effect.{ExitCode, IO, IOApp}
 import com.permutive.pubsub.consumer.Model
 import com.permutive.pubsub.consumer.decoder.MessageDecoder
+import scala.annotation.nowarn
 
+@nowarn("cat=deprecation")
 object SimpleDriver extends IOApp {
   case class ValueHolder(value: String) extends AnyVal
 

--- a/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/producer/grpc/PubsubProducerExample.scala
+++ b/fs2-google-pubsub-grpc/src/test/scala/com/permutive/pubsub/producer/grpc/PubsubProducerExample.scala
@@ -21,7 +21,9 @@ import com.permutive.pubsub.producer.Model
 import com.permutive.pubsub.producer.encoder.MessageEncoder
 
 import scala.concurrent.duration._
+import scala.annotation.nowarn
 
+@nowarn("cat=deprecation")
 object PubsubProducerExample extends IOApp {
 
   case class Value(v: Int) extends AnyVal

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumer.scala
@@ -32,6 +32,7 @@ import org.http4s.client.middleware.RetryPolicy.{exponentialBackoff, recklesslyR
 
 import java.util.Base64
 import scala.concurrent.duration._
+import scala.annotation.nowarn
 
 object PubsubHttpConsumer {
 
@@ -48,6 +49,10 @@ object PubsubHttpConsumer {
     *  - https://cloud.google.com/compute/docs/metadata/default-metadata-values
     *  - https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances
     */
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   final def subscribe[F[_]: Async: Logger, A: MessageDecoder](
     projectId: ProjectId,
     subscription: Subscription,
@@ -55,7 +60,7 @@ object PubsubHttpConsumer {
     config: PubsubHttpConsumerConfig[F],
     httpClient: Client[F],
     errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
-    httpClientRetryPolicy: RetryPolicy[F] = recklesslyRetryPolicy[F]
+    httpClientRetryPolicy: RetryPolicy[F] = recklesslyRetryPolicy[F]: @nowarn
   ): Stream[F, ConsumerRecord[F, A]] =
     subscribeDecode[F, A, ConsumerRecord[F, A]](
       projectId,
@@ -81,6 +86,10 @@ object PubsubHttpConsumer {
     *  - https://cloud.google.com/compute/docs/metadata/default-metadata-values
     *  - https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances
     */
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   final def subscribeAndAck[F[_]: Async: Logger, A: MessageDecoder](
     projectId: ProjectId,
     subscription: Subscription,
@@ -88,7 +97,7 @@ object PubsubHttpConsumer {
     config: PubsubHttpConsumerConfig[F],
     httpClient: Client[F],
     errorHandler: (PubsubMessage, Throwable, F[Unit], F[Unit]) => F[Unit],
-    httpClientRetryPolicy: RetryPolicy[F] = recklesslyRetryPolicy[F]
+    httpClientRetryPolicy: RetryPolicy[F] = recklesslyRetryPolicy[F]: @nowarn
   ): Stream[F, A] =
     subscribeDecode[F, A, A](
       projectId,
@@ -113,13 +122,17 @@ object PubsubHttpConsumer {
     *  - https://cloud.google.com/compute/docs/metadata/default-metadata-values
     *  - https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances
     */
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   final def subscribeRaw[F[_]: Async: Logger](
     projectId: ProjectId,
     subscription: Subscription,
     serviceAccountPath: Option[String],
     config: PubsubHttpConsumerConfig[F],
     httpClient: Client[F],
-    httpClientRetryPolicy: RetryPolicy[F] = recklesslyRetryPolicy[F],
+    httpClientRetryPolicy: RetryPolicy[F] = recklesslyRetryPolicy[F]: @nowarn,
   ): Stream[F, ConsumerRecord[F, PubsubMessage]] =
     PubsubSubscriber
       .subscribe(projectId, subscription, serviceAccountPath, config, httpClient, httpClientRetryPolicy)
@@ -129,9 +142,17 @@ object PubsubHttpConsumer {
     Pub/Sub requests are `POST` and thus are not considered idempotent by http4s, therefore we must
     use a different retry behaviour than the default.
    */
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def recklesslyRetryPolicy[F[_]]: RetryPolicy[F] =
     RetryPolicy(exponentialBackoff(maxWait = 5.seconds, maxRetry = 3), (_, result) => recklesslyRetriable(result))
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   private def subscribeDecode[F[_]: Async: Logger, A: MessageDecoder, B](
     projectId: ProjectId,
     subscription: Subscription,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumerConfig.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubHttpConsumerConfig.scala
@@ -42,6 +42,10 @@ import scala.concurrent.duration._
   * @param readMaxMessages                   how many messages to retrieve at once simultaneously
   * @param readConcurrency                   how much parallelism to use when fetching messages from PubSub
   */
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 case class PubsubHttpConsumerConfig[F[_]](
   host: String = "pubsub.googleapis.com",
   port: Int = 443,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubMessage.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/PubsubMessage.scala
@@ -19,6 +19,10 @@ package com.permutive.pubsub.consumer.http
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import com.github.plokhotnyuk.jsoniter_scala.macros.{CodecMakerConfig, JsonCodecMaker}
 
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 case class PubsubMessage(
   data: String,
   attributes: Map[String, String],
@@ -27,6 +31,10 @@ case class PubsubMessage(
 )
 
 object PubsubMessage {
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   implicit final val Codec: JsonValueCodec[PubsubMessage] =
     JsonCodecMaker.make[PubsubMessage](CodecMakerConfig)
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/HttpPubsubReader.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/HttpPubsubReader.scala
@@ -57,6 +57,10 @@ private[internal] class HttpPubsubReader[F[_]: Async: Logger] private (
   final private[this] val acknowledgeEndpoint    = appendToUrl("acknowledge")
   final private[this] val modifyDeadlineEndpoint = appendToUrl("modifyAckDeadline")
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   final override val read: F[PullResponse] = {
     for {
       json <- Sync[F].delay(
@@ -119,6 +123,10 @@ private[internal] class HttpPubsubReader[F[_]: Async: Logger] private (
 }
 
 private[internal] object HttpPubsubReader {
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def resource[F[_]: Async: Logger](
     projectId: ProjectId,
     subscription: Subscription,
@@ -168,6 +176,10 @@ private[internal] object HttpPubsubReader {
       maxMessages = config.readMaxMessages
     )
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def createBaseApi[F[_]](config: PubsubHttpConsumerConfig[F], projectNameSubscription: ProjectNameSubscription): Uri =
     Uri(
       scheme = Option(if (config.port == 443) Uri.Scheme.https else Uri.Scheme.http),

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/Model.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/Model.scala
@@ -22,14 +22,23 @@ import com.permutive.pubsub.consumer.http.PubsubMessage
 import com.permutive.pubsub.consumer.{ConsumerRecord, Model => PublicModel}
 
 import scala.concurrent.duration.FiniteDuration
+import scala.annotation.nowarn
 
 private[http] object Model {
   case class ProjectNameSubscription(value: String) extends AnyVal
   object ProjectNameSubscription {
+    @deprecated(
+      "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+      since = "0.22.2"
+    )
     def of(projectId: PublicModel.ProjectId, subscription: PublicModel.Subscription): ProjectNameSubscription =
       ProjectNameSubscription(s"projects/${projectId.value}/subscriptions/${subscription.value}")
   }
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   trait InternalRecord[F[_]] { self =>
     def value: PubsubMessage
     def ack: F[Unit]
@@ -59,18 +68,30 @@ private[http] object Model {
       JsonCodecMaker.make[PullRequest](CodecMakerConfig)
   }
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   case class PullResponse(
     receivedMessages: List[ReceivedMessage]
   )
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   object PullResponse {
     implicit final val PullResponseCodec: JsonValueCodec[PullResponse] =
       JsonCodecMaker.make[PullResponse](CodecMakerConfig)
   }
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   case class ReceivedMessage(
     ackId: AckId,
-    message: PubsubMessage
+    @nowarn message: PubsubMessage
   )
 
   case class AckRequest(

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubReader.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubReader.scala
@@ -21,6 +21,10 @@ import com.permutive.pubsub.consumer.http.internal.Model.{AckId, PullResponse}
 import scala.concurrent.duration.FiniteDuration
 
 trait PubsubReader[F[_]] {
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def read: F[PullResponse]
 
   def ack(ackId: List[AckId]): F[Unit]

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubSubscriber.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/consumer/http/internal/PubsubSubscriber.scala
@@ -32,6 +32,10 @@ import scala.concurrent.duration.FiniteDuration
 
 private[http] object PubsubSubscriber {
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def subscribe[F[_]: Logger: Async](
     projectId: ProjectId,
     subscription: Subscription,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/AccessToken.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/AccessToken.scala
@@ -19,9 +19,17 @@ package com.permutive.pubsub.http.oauth
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros._
 
+@deprecated(
+  "Use `gcp-auth` instead. Replace with: `\"com.permutive\" %% \"gcp-auth\" % \"0.2.0\"",
+  since = "0.22.2"
+)
 final case class AccessToken(accessToken: String, tokenType: String, expiresIn: Int)
 
 object AccessToken {
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   implicit final val codec: JsonValueCodec[AccessToken] =
     JsonCodecMaker.make[AccessToken](
       CodecMakerConfig.withFieldNameMapper(JsonCodecMaker.enforce_snake_case)

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/CachedTokenProvider.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/CachedTokenProvider.scala
@@ -33,6 +33,10 @@ object CachedTokenProvider {
     * @param onNewToken            a callback invoked whenever a new token is generated, the [[scala.concurrent.duration.FiniteDuration]]
     *                              is the period that will be waited before the next new token
     */
+  @deprecated(
+    "Use `gcp-auth` instead. Replace with: `\"com.permutive\" %% \"gcp-auth\" % \"0.2.0\"",
+    since = "0.22.2"
+  )
   def resource[F[_]: Temporal](
     underlying: TokenProvider[F],
     safetyPeriod: FiniteDuration,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/DefaultTokenProvider.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/DefaultTokenProvider.scala
@@ -31,6 +31,11 @@ class DefaultTokenProvider[F[_]: Clock](
   auth: OAuth[F]
 )(implicit F: MonadError[F, Throwable])
     extends TokenProvider[F] {
+
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   override val accessToken: F[AccessToken] = {
     for {
       now <- Clock[F].realTimeInstant
@@ -48,6 +53,10 @@ class DefaultTokenProvider[F[_]: Clock](
 object DefaultTokenProvider {
   final private val scope = List("https://www.googleapis.com/auth/pubsub")
 
+  @deprecated(
+    "Use `gcp-auth` instead. Replace with: `\"com.permutive\" %% \"gcp-auth\" % \"0.2.0\"",
+    since = "0.22.2"
+  )
   def google[F[_]: Logger: Async](
     serviceAccountPath: String,
     httpClient: Client[F]
@@ -60,9 +69,17 @@ object DefaultTokenProvider {
       new GoogleOAuth(serviceAccount.privateKey, httpClient)
     )
 
+  @deprecated(
+    "Use `gcp-auth` instead. Replace with: `\"com.permutive\" %% \"gcp-auth\" % \"0.2.0\"",
+    since = "0.22.2"
+  )
   def instanceMetadata[F[_]: Async: Logger](httpClient: Client[F]): TokenProvider[F] =
     new DefaultTokenProvider[F]("instance-metadata", scope, new InstanceMetadataOAuth[F](httpClient))
 
+  @deprecated(
+    "Use `gcp-auth` instead. Replace with: `\"com.permutive\" %% \"gcp-auth\" % \"0.2.0\"",
+    since = "0.22.2"
+  )
   def noAuth[F[_]: Clock](implicit F: MonadError[F, Throwable]): TokenProvider[F] =
     new DefaultTokenProvider("noop", Nil, new NoopOAuth)
 }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/GoogleOAuth.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/GoogleOAuth.scala
@@ -48,6 +48,10 @@ class GoogleOAuth[F[_]: Async: Logger](
   final private[this] val googleOAuthDomainStr = "https://www.googleapis.com/oauth2/v4/token"
   final private[this] val googleOAuthDomain    = Uri.unsafeFromString(googleOAuthDomainStr)
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   final override def authenticate(
     iss: String,
     scope: String,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/InstanceMetadataOAuth.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/InstanceMetadataOAuth.scala
@@ -45,6 +45,10 @@ class InstanceMetadataOAuth[F[_]: Async: Logger](httpClient: Client[F]) extends 
   final private[this] val request =
     GET(googleInstanceMetadataTokenUri, "Metadata-Flavor" -> "Google")
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   private[this] val doAuthenticate: F[Option[AccessToken]] =
     httpClient
       .expectOr[Array[Byte]](request) { resp =>
@@ -53,6 +57,10 @@ class InstanceMetadataOAuth[F[_]: Async: Logger](httpClient: Client[F]) extends 
       .flatMap(bytes => Sync[F].delay(readFromArray[AccessToken](bytes)).map(_.some))
       .handleErrorWith(Logger[F].warn(_)("Failed to retrieve JWT Access Token from Google").as(None))
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   override def authenticate(iss: String, scope: String, exp: Instant, iat: Instant): F[Option[AccessToken]] =
     doAuthenticate
 

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/NoopOAuth.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/NoopOAuth.scala
@@ -23,6 +23,10 @@ import cats.Applicative
 import scala.concurrent.duration._
 
 class NoopOAuth[F[_]](implicit F: Applicative[F]) extends OAuth[F] {
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   final override def authenticate(iss: String, scope: String, exp: Instant, iat: Instant): F[Option[AccessToken]] =
     F.pure(Some(AccessToken("noop", "noop", 3600)))
 

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/OAuth.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/OAuth.scala
@@ -28,6 +28,10 @@ trait OAuth[F[_]] {
     * @param exp The expiration time of the assertion, specified as milliseconds since 00:00:00 UTC, January 1, 1970.
     * @param iat The time the assertion was issued, specified as milliseconds since 00:00:00 UTC, January 1, 1970.
     */
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def authenticate(
     iss: String,
     scope: String,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/RequestAuthorizer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/RequestAuthorizer.scala
@@ -29,6 +29,10 @@ trait RequestAuthorizer[F[_]] {
 
 object RequestAuthorizer {
 
+  @deprecated(
+    "Use `gcp-auth` instead. Replace with: `\"com.permutive\" %% \"gcp-auth\" % \"0.2.0\"",
+    since = "0.22.2"
+  )
   def tokenProvider[F[_]: Functor](tokenProvider: TokenProvider[F]): RequestAuthorizer[F] =
     new RequestAuthorizer[F] {
       override def authorize(request: Request[F]): F[Request[F]] =

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/TokenProvider.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/oauth/TokenProvider.scala
@@ -19,6 +19,10 @@ package com.permutive.pubsub.http.oauth
 import scala.util.control.NoStackTrace
 
 trait TokenProvider[F[_]] {
+  @deprecated(
+    "Use `gcp-auth` instead. Replace with: `\"com.permutive\" %% \"gcp-auth\" % \"0.2.0\"",
+    since = "0.22.2"
+  )
   def accessToken: F[AccessToken]
 }
 
@@ -29,6 +33,10 @@ object TokenProvider {
 
   case object FailedToGetToken extends RuntimeException("Failed to get token after many attempts")
 
+  @deprecated(
+    "Use `gcp-auth` instead. Replace with: `\"com.permutive\" %% \"gcp-auth\" % \"0.2.0\"",
+    since = "0.22.2"
+  )
   def instance[F[_]](token: F[AccessToken]): TokenProvider[F] = new TokenProvider[F] {
     override val accessToken: F[AccessToken] = token
   }

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/util/RefreshableEffect.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/http/util/RefreshableEffect.scala
@@ -30,6 +30,10 @@ import scala.concurrent.duration.FiniteDuration
   *
   * Implementation is backed by a `cats-effect` `Ref` so evaluating the value is fast.
   */
+@deprecated(
+  "Use `refreshable` instead. Replace with: `\"com.permutive\" %% \"refreshable\" % \"1.1.0\"",
+  since = "0.22.2"
+)
 final class RefreshableEffect[F[_], A] private (val value: F[A], val cancelToken: F[Unit])
 
 object RefreshableEffect {
@@ -45,6 +49,10 @@ object RefreshableEffect {
     * @param retryMaxAttempts   how many attempts to make before failing with last error
     * @param onRetriesExhausted what to do if retrying to refresh the value fails, up to user handle failing their service
     */
+  @deprecated(
+    "Use `refreshable` instead. Replace with: `\"com.permutive\" %% \"refreshable\" % \"1.1.0\"",
+    since = "0.22.2"
+  )
   def createRetryResource[F[_]: Temporal, A](
     refresh: F[A],
     refreshInterval: FiniteDuration,
@@ -67,6 +75,10 @@ object RefreshableEffect {
     Resource.make(createAndSchedule(refresh, refreshInterval, updateRef))(_.cancelToken)
   }
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   private def createAndSchedule[F[_]: Temporal, A](
     refresh: F[A],
     refreshInterval: FiniteDuration,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpProducerConfig.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpProducerConfig.scala
@@ -18,6 +18,10 @@ package com.permutive.pubsub.producer.http
 
 import scala.concurrent.duration.FiniteDuration
 
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 case class BatchingHttpProducerConfig(
   batchSize: Int,
   maxLatency: FiniteDuration,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpPubsubProducer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/BatchingHttpPubsubProducer.scala
@@ -37,6 +37,10 @@ object BatchingHttpPubsubProducer {
     *  - https://cloud.google.com/compute/docs/metadata/default-metadata-values
     *  - https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances
     */
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def resource[F[_]: Async: Logger, A: MessageEncoder](
     projectId: Model.ProjectId,
     topic: Model.Topic,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/HttpPubsubProducer.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/HttpPubsubProducer.scala
@@ -37,6 +37,10 @@ object HttpPubsubProducer {
     *  - https://cloud.google.com/compute/docs/metadata/default-metadata-values
     *  - https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances
     */
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def resource[F[_]: Async: Logger, A: MessageEncoder](
     projectId: Model.ProjectId,
     topic: Model.Topic,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/PubsubHttpProducerConfig.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/PubsubHttpProducerConfig.scala
@@ -37,6 +37,10 @@ import scala.concurrent.duration._
   *                                          See note above on exceptions, up to the *user* to raise exceptions in their
   *                                          service using this callback if required.
   */
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 case class PubsubHttpProducerConfig[F[_]](
   host: String = "pubsub.googleapis.com",
   port: Int = 443,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/BatchingHttpPublisher.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/BatchingHttpPublisher.scala
@@ -26,6 +26,10 @@ import com.permutive.pubsub.producer.http.BatchingHttpProducerConfig
 import com.permutive.pubsub.producer.{AsyncPubsubProducer, Model, PubsubProducer}
 import fs2.{Chunk, Stream}
 
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 private[http] class BatchingHttpPublisher[F[_]: Concurrent, A] private (
   queue: QueueSink[F, Model.AsyncRecord[F, A]]
 ) extends AsyncPubsubProducer[F, A] {
@@ -60,6 +64,11 @@ private[http] class BatchingHttpPublisher[F[_]: Concurrent, A] private (
 }
 
 private[http] object BatchingHttpPublisher {
+
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def resource[F[_]: Temporal, A](
     publisher: PubsubProducer[F, A],
     config: BatchingHttpProducerConfig
@@ -69,6 +78,10 @@ private[http] object BatchingHttpPublisher {
       _     <- Resource.make(consume(publisher, config, queue).start)(_.cancel)
     } yield new BatchingHttpPublisher(queue)
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   private def consume[F[_]: Temporal, A](
     underlying: PubsubProducer[F, A],
     config: BatchingHttpProducerConfig,

--- a/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/DefaultHttpPublisher.scala
+++ b/fs2-google-pubsub-http/src/main/scala/com/permutive/pubsub/producer/http/internal/DefaultHttpPublisher.scala
@@ -38,7 +38,12 @@ import org.typelevel.log4cats.Logger
 
 import java.util.Base64
 import scala.concurrent.duration._
+import scala.annotation.nowarn
 
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 private[http] class DefaultHttpPublisher[F[_]: Async: Logger, A: MessageEncoder] private (
   baseApiUrl: Uri,
   client: Client[F],
@@ -93,6 +98,10 @@ private[http] class DefaultHttpPublisher[F[_]: Async: Logger, A: MessageEncoder]
 
 private[http] object DefaultHttpPublisher {
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def resource[F[_]: Async: Logger, A: MessageEncoder](
     projectId: Model.ProjectId,
     topic: Model.Topic,
@@ -140,6 +149,10 @@ private[http] object DefaultHttpPublisher {
       requestAuthorizer = RequestAuthorizer.tokenProvider(tokenProvider),
     )
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def createBaseApiUri[F[_]](
     projectId: Model.ProjectId,
     topic: Model.Topic,
@@ -157,11 +170,20 @@ private[http] object DefaultHttpPublisher {
     attributes: Map[String, String]
   )
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   case class MessageBundle[G[_]](
     messages: G[Message]
   )
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   case class MessageIds(
+    @nowarn
     messageIds: List[MessageId]
   )
 
@@ -181,6 +203,10 @@ private[http] object DefaultHttpPublisher {
   implicit final val MessageCodec: JsonValueCodec[Message] =
     JsonCodecMaker.make[Message](CodecMakerConfig)
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   implicit final def messageBundleCodec[G[_]](implicit
     Codec: JsonValueCodec[G[Message]]
   ): JsonValueCodec[MessageBundle[G]] =
@@ -197,6 +223,10 @@ private[http] object DefaultHttpPublisher {
       override def nullValue: MessageBundle[G] = ???
     }
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   implicit final val MessageIdsCodec: JsonValueCodec[MessageIds] =
     JsonCodecMaker.make[MessageIds](CodecMakerConfig)
 

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/HttpPingPongSpec.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/HttpPingPongSpec.scala
@@ -31,7 +31,9 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.concurrent.duration._
+import scala.annotation.nowarn
 
+@nowarn("cat=deprecation")
 class HttpPingPongSpec extends PubSubSpec with BeforeAndAfterEach {
 
   implicit val logger: Logger[IO] = Slf4jLogger.getLogger

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/PubSubSpec.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/PubSubSpec.scala
@@ -43,7 +43,9 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.testcontainers.containers.wait.strategy.Wait
 import org.typelevel.log4cats.Logger
+import scala.annotation.nowarn
 
+@nowarn("cat=deprecation")
 trait PubSubSpec extends AnyFlatSpec with ForAllTestContainer with Matchers with TripleEquals {
 
   implicit val logger: Logger[IO]

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/consumer/http/Example.scala
@@ -27,7 +27,9 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.util.Try
+import scala.annotation.nowarn
 
+@nowarn("cat=deprecation")
 object Example extends IOApp {
   case class ValueHolder(value: String) extends AnyVal
 

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleBatching.scala
@@ -27,7 +27,9 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.concurrent.duration._
 import scala.util.Try
+import scala.annotation.nowarn
 
+@nowarn("cat=deprecation")
 object ExampleBatching extends IOApp {
 
   implicit final val Codec: JsonValueCodec[ExampleObject] =

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleEmulator.scala
@@ -27,7 +27,9 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.concurrent.duration._
 import scala.util.Try
+import scala.annotation.nowarn
 
+@nowarn("cat=deprecation")
 object ExampleEmulator extends IOApp {
 
   implicit final val Codec: JsonValueCodec[ExampleObject] =

--- a/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
+++ b/fs2-google-pubsub-http/src/test/scala/com/permutive/pubsub/producer/http/ExampleGoogle.scala
@@ -27,7 +27,9 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.concurrent.duration._
 import scala.util.Try
+import scala.annotation.nowarn
 
+@nowarn("cat=deprecation")
 object ExampleGoogle extends IOApp {
 
   implicit final val Codec: JsonValueCodec[ExampleObject] =

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/consumer/ConsumerRecord.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/consumer/ConsumerRecord.scala
@@ -21,6 +21,10 @@ import cats.syntax.show._
 
 import scala.concurrent.duration.FiniteDuration
 
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 trait ConsumerRecord[F[_], A] {
   def value: A
   def attributes: Map[String, String]
@@ -29,10 +33,18 @@ trait ConsumerRecord[F[_], A] {
   def extendDeadline(by: FiniteDuration): F[Unit]
 }
 
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 object ConsumerRecord {
   implicit def show[F[_], A: Show]: Show[ConsumerRecord[F, A]] =
     (record: ConsumerRecord[F, A]) => s"Record(${record.value.show})"
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   abstract private[this] case class RecordImpl[F[_], A](
     value: A,
     attributes: Map[String, String],
@@ -40,6 +52,10 @@ object ConsumerRecord {
     nack: F[Unit],
   ) extends ConsumerRecord[F, A]
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def apply[F[_], A](
     value: A,
     attributes: Map[String, String],

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/consumer/Model.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/consumer/Model.scala
@@ -19,13 +19,30 @@ package com.permutive.pubsub.consumer
 import cats.Show
 
 object Model {
+
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   case class ProjectId(value: String) extends AnyVal
   object ProjectId {
+    @deprecated(
+      "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+      since = "0.22.2"
+    )
     implicit val show: Show[ProjectId] = Show.fromToString
   }
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   case class Subscription(value: String) extends AnyVal
   object Subscription {
+    @deprecated(
+      "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+      since = "0.22.2"
+    )
     implicit val show: Show[Subscription] = Show.fromToString
   }
 }

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/consumer/decoder/MessageDecoder.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/consumer/decoder/MessageDecoder.scala
@@ -18,13 +18,25 @@ package com.permutive.pubsub.consumer.decoder
 
 import cats.Functor
 
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 trait MessageDecoder[A] {
   def decode(message: Array[Byte]): Either[Throwable, A]
 }
 
 object MessageDecoder {
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def apply[A: MessageDecoder]: MessageDecoder[A] = implicitly
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   implicit val functor: Functor[MessageDecoder] = new Functor[MessageDecoder] {
 
     override def map[A, B](fa: MessageDecoder[A])(f: A => B): MessageDecoder[B] =

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/AsyncPubsubProducer.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/AsyncPubsubProducer.scala
@@ -20,6 +20,10 @@ import java.util.UUID
 
 import cats.{Foldable, Traverse}
 
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 trait AsyncPubsubProducer[F[_], A] {
   def produceAsync(
     data: A,

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/Model.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/Model.scala
@@ -19,22 +19,48 @@ package com.permutive.pubsub.producer
 import java.util.UUID
 
 object Model {
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   case class MessageId(value: String) extends AnyVal
-  case class ProjectId(value: String) extends AnyVal
-  case class Topic(value: String)     extends AnyVal
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
+  case class ProjectId(value: String) extends AnyVal
+
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
+  case class Topic(value: String) extends AnyVal
+
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   trait Record[A] {
     def data: A
     def attributes: Map[String, String]
     def uniqueId: String
   }
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   final case class SimpleRecord[A](
     data: A,
     attributes: Map[String, String] = Map.empty,
     uniqueId: String = UUID.randomUUID().toString
   ) extends Record[A]
 
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   final case class AsyncRecord[F[_], A](
     data: A,
     callback: Either[Throwable, Unit] => F[Unit],

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/PubsubProducer.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/PubsubProducer.scala
@@ -21,6 +21,10 @@ import java.util.UUID
 import cats.Traverse
 import com.permutive.pubsub.producer.Model.MessageId
 
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 trait PubsubProducer[F[_], A] {
   def produce(
     data: A,

--- a/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/encoder/MessageEncoder.scala
+++ b/fs2-google-pubsub/src/main/scala/com/permutive/pubsub/producer/encoder/MessageEncoder.scala
@@ -16,10 +16,18 @@
 
 package com.permutive.pubsub.producer.encoder
 
+@deprecated(
+  "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+  since = "0.22.2"
+)
 trait MessageEncoder[A] {
   def encode(a: A): Either[Throwable, Array[Byte]]
 }
 
 object MessageEncoder {
+  @deprecated(
+    "Use `fs2-pubsub` instead. Replace with: `\"com.permutive\" %% \"fs2-pubsub\" % \"1.0.0\"`",
+    since = "0.22.2"
+  )
   def apply[A: MessageEncoder]: MessageEncoder[A] = implicitly
 }


### PR DESCRIPTION
This PR adds a bunch of deprecation notices around the codebase so users know a new library has been published. We believe this is better than providing an artifact migration for Scala Steward since the two libraries are not source-compatible.

The new library has been added in https://github.com/permutive-engineering/fs2-google-pubsub/pull/533.